### PR TITLE
Modification of HLLHC error routines inorder to load magnet rotation from table

### DIFF
--- a/submodule_04c_errortables.madx
+++ b/submodule_04c_errortables.madx
@@ -9,6 +9,16 @@ if (on_errors_LHC==1){
   readtable, file="errors/LHC/rotations_Q2_integral.tab";
 };
 
+if (ver_hllhc_optics == 1.4){
+  readtable, file="errors/HL-LHC/Layout_Rotations_HLLHCv1.4.tab";
+};
+if (ver_hllhc_optics == 1.5){
+  readtable, file="errors/HL-LHC/Layout_Rotations_HLLHCv1.5.tab";
+};
+if (ver_hllhc_optics == 1.6){
+  readtable, file="errors/HL-LHC/Layout_Rotations_HLLHCv1.6.tab";
+};
+
 if (ver_hllhc_optics > 0 && on_errors_IT==1){
   call, file="errors/HL-LHC/ITbody_errortable_v5"; ! target error table for the new IT
   call, file="errors/HL-LHC/ITnc_errortable_v5"; ! target error table for the new IT


### PR DESCRIPTION
I add those line in order to load tables containing magnet orientation for HLLHC v1.4,v1.5 and v1.6. There are no change in the magnet orientation between v1.5 and v1.6.